### PR TITLE
feat: initialize stations progress in game store

### DIFF
--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { stations as stationsData } from "@/data/station";
 
 type StationProgress = {
   id: string;
@@ -13,17 +14,23 @@ type GameState = {
   resetGame: () => void;
 };
 
+const initialStations: StationProgress[] = stationsData.map((station) => ({
+  id: station.id,
+  completed: false,
+  answer: "",
+}));
+
 export const useGameStore = create<GameState>()(
   persist(
     (set) => ({
-      stations: [],
+      stations: initialStations,
       completeStation: (id: string, answer: string) =>
         set((state: GameState) => ({
           stations: state.stations.map((s) =>
             s.id === id ? { ...s, completed: true, answer } : s,
           ),
         })),
-      resetGame: () => set({ stations: [] }),
+      resetGame: () => set({ stations: initialStations }),
     }),
     { name: "finnegans-game-progress" },
   ),


### PR DESCRIPTION
The stationsProgress array was previously empty because the stations in the game store were not being initialized. This commit fixes the issue by importing the station data and using it to create the initial state for the stations array. The resetGame function is also updated to reset to this initial state.